### PR TITLE
Location hours

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,22 @@
 exit
+hours["stores"].first["hoursAmPm"]
+hours["stores"].first["hours"]
+hours["stores"].first
+hours["stores"].hours
+hours["stores"]
+hours["stores"]["name"]
+hours["stores"]
+hours["stores"]["hoursAmPm"]
+pp hours["stores"]["hoursAmPm"]
+pp hours["stores"]["hours"]
+pp hours["stores"]
+pp hours["stores"]["hoursAmPm"]
+pp hours["hoursAmPm"]
+pp hours["hours"]
+pp hours
+exit
+params
+exit
 locations["stores"]
 exit
 store["stores"]["storeId"]

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,9 @@
 class SearchController < ApplicationController
   def index
-    @stores = Store.make_stores(params[:search])
+    @stores = Store.make_stores(params[:id])
+  end
+
+  def show
+
   end
 end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -1,0 +1,5 @@
+class StoresController < ApplicationController
+  def show
+    @store = params[:store]
+  end
+end

--- a/app/services/best_buy_service.rb
+++ b/app/services/best_buy_service.rb
@@ -4,4 +4,10 @@ class BestBuyService
     response = conn.get("stores(area(#{zipcode},#{distance}))?format=json&show=storeId,storeType,name,phone,city,distance&pageSize=25&apiKey=#{ENV['BEST_BUY_KEY']}")
     JSON.parse(response.body)
   end
+
+  def find_by_id(id)
+    conn = Faraday.new("https://api.bestbuy.com/v1")
+    response = conn.get("stores(storeId=#{id})?format=json&show=storeId,storeType,name,address,city,region,hours,hoursAmPm,gmtOffset,detailedHours.open&apiKey=#{ENV['BEST_BUY_KEY']}")
+    JSON.parse(response.body)
+  end
 end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,7 +1,7 @@
 <%= @stores.count %> Total Stores
 
 <% @stores.each do |store| %>
-<h3><%= link_to store.name, search_path(store.id) %> </h3>
+<h3><%= link_to store.name, store_path(store.id), {:controller => "stores", :action => "show", :store => store.id } %> </h3>
 <h5><%= store.city %></h5>
 <h5><%= store.distance %></h5> miles
 <h5><%= store.phone_number %></h5>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,7 +1,7 @@
 <%= @stores.count %> Total Stores
 
 <% @stores.each do |store| %>
-<h3><%= store.name %></h3>
+<h3><%= link_to store.name, search_path(store.id) %> </h3>
 <h5><%= store.city %></h5>
 <h5><%= store.distance %></h5> miles
 <h5><%= store.phone_number %></h5>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   resources :items,  only: [:index, :show]
   resources :orders, only: [:index, :show]
   resources :users,  only: [:index, :show]
-  resources :search, only: [:index]
+  resources :search, only: [:index, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,6 @@ Rails.application.routes.draw do
   resources :items,  only: [:index, :show]
   resources :orders, only: [:index, :show]
   resources :users,  only: [:index, :show]
-  resources :search, only: [:index, :show]
+  resources :search, only: [:index]
+  resources :stores, only: [:show]
 end

--- a/spec/features/user_can_see_location_hours_spec.rb
+++ b/spec/features/user_can_see_location_hours_spec.rb
@@ -1,0 +1,32 @@
+# The name will be a link in the next story:
+#
+# As a user
+# After I have searched a zip code for stores
+# When I click the name of a store
+# Then my current path should be "/stores/:store_id"
+# I should see the store name, store type and address with city, state and zip
+# I should see an unordered list of the store hours in the following format:
+#   * Mon: 10am-9pm
+#   * Tue: 10am-9pm
+#   * Wed: 10am-9pm
+#   * Thurs: 10am-9pm
+#   * Fri: 10am-9pm
+#   * Sat: 10am-9pm
+#   * Sun: 11am-7pm
+
+require "rails_helper"
+
+RSpec.feature "user can see location store hours" do
+  scenario "a user clicks on a link of a store to get store hours" do
+    VCR.use_cassette("locations_by_zipcode") do
+      visit "/"
+      fill_in :search, with: "80202"
+      click_button "Submit"
+      click_link("Cherry Creek Shopping Center")
+      expect(current_path).to eq("/stores/1224")
+      expect(page).to have_content("Cherry Creek Shopping Center")
+      expect(page).to have_content("Address, Denver, 80123")
+      expect(page).to have_content("* Mon: 10am-9pm (hours)")
+    end
+  end
+end

--- a/spec/features/user_can_see_location_hours_spec.rb
+++ b/spec/features/user_can_see_location_hours_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "user can see location store hours" do
       fill_in :search, with: "80202"
       click_button "Submit"
       click_link("Cherry Creek Shopping Center")
-      expect(current_path).to eq("/stores/1224")
+      expect(current_path).to eq("/stores/2740")
       expect(page).to have_content("Cherry Creek Shopping Center")
       expect(page).to have_content("Address, Denver, 80123")
       expect(page).to have_content("* Mon: 10am-9pm (hours)")

--- a/spec/services/best_buy_service_spec.rb
+++ b/spec/services/best_buy_service_spec.rb
@@ -14,4 +14,15 @@ describe BestBuyService do
       end
     end
   end
+
+  context "find_by_location" do
+    it "returns locations by zipcode" do
+      VCR.use_cassette("store hours") do
+        store_id = 2740
+        best_buy_service = BestBuyService.new
+        hours = best_buy_service.find_by_id(store_id)
+        expect(hours["stores"].first["hoursAmPm"]).to eq("Mon: 10am-9pm; Tue: 10am-9pm; Wed: 10am-9pm; Thurs: 10am-9pm; Fri: 10am-9pm; Sat: 10am-9pm; Sun: 11am-6pm")
+      end
+    end
+  end
 end


### PR DESCRIPTION
The name will be a link in the next story:

As a user
After I have searched a zip code for stores
When I click the name of a store
Then my current path should be "/stores/:store_id"
I should see the store name, store type and address with city, state and zip
I should see an unordered list of the store hours in the following format:
- Mon: 10am-9pm
- Tue: 10am-9pm
- Wed: 10am-9pm
- Thurs: 10am-9pm
- Fri: 10am-9pm
- Sat: 10am-9pm
- Sun: 11am-7pm
